### PR TITLE
reduce Vec2f and String allocations in model.obj

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/model/obj/Face.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/obj/Face.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class Face {
 	public String mtl;
-	public Vec2f offsetUV = new Vec2f(0, 0);
+	public Vec2f offsetUV = Vec2f.ZERO;
 	public Float depthCache;
 	private int pointStart;
 	private OBJModel model;

--- a/src/main/java/cam72cam/immersiverailroading/model/obj/OBJModel.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/obj/OBJModel.java
@@ -68,7 +68,7 @@ public class OBJModel {
 				materialPaths.add(args[0]);
 				break;
 			case "usemtl":
-				currentMaterial = args[0];
+				currentMaterial = args[0].intern();
 				break;
 			case "o":
 			case "g":

--- a/src/main/java/cam72cam/immersiverailroading/model/obj/Vec2f.java
+++ b/src/main/java/cam72cam/immersiverailroading/model/obj/Vec2f.java
@@ -2,12 +2,29 @@ package cam72cam.immersiverailroading.model.obj;
 
 public class Vec2f {
 
-	public float x;
-	public float y;
+	public static final Vec2f ZERO = new Vec2f(0, 0);
+
+	public final float x;
+	public final float y;
 
 	public Vec2f(float x, float y) {
 		this.x = x;
 		this.y = y;
+	}
+
+	@Override
+	public boolean equals(Object other) {
+		if (!(other instanceof Vec2f)) {
+			return false;
+		} else {
+			Vec2f v = (Vec2f) other;
+			return v.x == x && v.y == y;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Float.hashCode(x) * 31 + Float.hashCode(y);
 	}
 
 }

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -364,11 +364,11 @@ public abstract class EntityRollingStockDefinition {
 							vert = vert.addVector(this.frontBounds, 0, this.widthBounds/2);
 							if (first) {
 								path.moveTo(vert.x * ratio, vert.z * ratio);
+								first = false;
 							} else {
 								path.lineTo(vert.x * ratio, vert.z * ratio);
 							}
 							fheight += vert.y / face.points().length;
-							first = false;
 						}
 						Rectangle2D bounds = path.getBounds2D();
 						if (bounds.getWidth() * bounds.getHeight() < 1) {


### PR DESCRIPTION
The Vec2f allocation reduction saves ~50MB, the String interning saves ~200KB. The amount of non-zero UV offset Vec2f is so small as to not be worth reducing further.

Unfortunately, the mod's models still consume about 200MB even with the reduction. The format should probably be optimized for memory usage further.