### PR TITLE
Update Skookum Tender - Empty Weight and Coal Capacity

### DIFF
--- a/src/main/resources/assets/immersiverailroading/rolling_stock/tender/skookum_tender.json
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/tender/skookum_tender.json
@@ -3,7 +3,7 @@
 	"model": "immersiverailroading:models/rolling_stock/tender/skookum_tender/skookum_tender.obj",
 	"darken_model": "-0.05",
 	"properties": {
-		"weight_kg": 21890
+		"weight_kg": 14805
 	},
 	"passenger": {
 		"slots": 2,
@@ -16,8 +16,8 @@
 		"capacity_l":  20000
 	},
 	"tender": {
-		"slots": 46,
-		"width": 16
+		"slots": 10,
+		"width": 5
 	},
 	"trucks": {
 		"front": 1.45, 

--- a/src/main/resources/assets/immersiverailroading/rolling_stock/tender/skookum_tender.json
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/tender/skookum_tender.json
@@ -13,7 +13,7 @@
 		"width": 1
 	},
 	"tank": {
-		"capacity_l":  20000
+		"capacity_l":  15000
 	},
 	"tender": {
 		"slots": 10,


### PR DESCRIPTION
Empty weight was a little heavy, reduced. Coal Capacity was over by almost 20 ton, Reduced to 10 slots. Loaded Tender weight should be closer to actual which is 40ton. (Though I'm not sure how the mod translates Buckets into kg).