### PR TITLE
Weight and Capacities

### DIFF
--- a/src/main/resources/assets/immersiverailroading/rolling_stock/tender/k4_tender.json
+++ b/src/main/resources/assets/immersiverailroading/rolling_stock/tender/k4_tender.json
@@ -3,7 +3,7 @@
 	"model": "immersiverailroading:models/rolling_stock/tender/k4_tender/k4_tender.obj",
 	"darken_model": "-0.05",
 	"properties": {
-		"weight_kg": 71890
+		"weight_kg": 32631
 	},
 	"passenger": {
 		"slots": 1,
@@ -13,11 +13,11 @@
 		"width": 1.5
 	},
 	"tank": {
-		"capacity_l":  26000
+		"capacity_l":  34000
 	},
 	"tender": {
-		"slots": 54,
-		"width": 18
+		"slots": 25,
+		"width": 13
 	},
 	"trucks": {
 		"front": 2.5, 


### PR DESCRIPTION
Original Water and LT Weight figures reflect AS DELIVERED tender specs, which are NOT for the tender that is modeled here. This model is the new PRR standard Short Haul Tender and has different weight and capacities. Tender Light Weight Reduced by OVER half. Water Capacity Increased. Coal capacity decreased to reflect Short Haul 17.5 US Ton Capacity.