### PR TITLE
Safer dismounts

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
@@ -251,10 +251,9 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 			
 			if (passenger instanceof EntityPlayer && !passenger.isDead && !this.isDead) {
 				if(!ppos.equals(passengerDismountAttempts.get(passenger.getPersistentID()))) {
-					delta = dismountFreePos(ppos, passenger);
+					delta = dismountFreePos(ppos, (EntityPlayer)passenger);
 					if (delta.y == -1) {
 						passengerDismountAttempts.put(passenger.getPersistentID(), ppos);
-						passenger.sendMessage(ChatText.DISMOUNT_FAIL.getMessage());
 						passenger.startRiding(this, true); // Should I override dismountRidingEntity for this instead?
 						return;
 					}
@@ -299,7 +298,7 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 		return delta.add(pos);
 	}
 	
-	public Vec3d dismountFreePos(Vec3d ppos, Entity passenger) {
+	public Vec3d dismountFreePos(Vec3d ppos, EntityPlayer passenger) {
 		float dismountAngle = ppos.z > 0 ? 90 : -90;
 		ppos = new Vec3d(ppos.x, ppos.y, 0);
 		Vec3d pos = this.getDefinition().getPassengerCenter(gauge);
@@ -332,12 +331,15 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 		
 		if ((dhstate.getCollisionBoundingBox(world, dhp) == null || BlockUtil.isIRRail(world, dhp)) && (dlstate.getCollisionBoundingBox(world, dlp) == null || BlockUtil.isIRRail(world, dlp))) {
 			if(!passenger.getEntityBoundingBox().offset(delta.subtract(passenger.getPositionVector())).intersects(this.getCollisionBoundingBox())) {
-				ImmersiveRailroading.info("Successful dismount at %s %s %s",  delta.x, delta.y, delta.z);
+				//ImmersiveRailroading.info("Successful dismount at %s %s %s",  delta.x, delta.y, delta.z);
 				return delta;
 			}
-			ImmersiveRailroading.info("Train obstructing dismount at %s %s %s, attempting to revert to default dismount point",  delta.x, delta.y, delta.z);
+			//ImmersiveRailroading.warn("Train obstructing dismount at %s %s %s, attempting to revert to default dismount point",  delta.x, delta.y, delta.z);
+			passenger.sendMessage(ChatText.DISMOUNT_DEFAULT.getMessage());
+			ImmersiveRailroading.warn("This is not intended to happen! Please contact the devs with the relavant train: %s", this.getDefinition().name());
 		} else {
-			ImmersiveRailroading.info("Block obstructing dismount at %s %s %s, attempting to revert to default dismount point", delta.x, delta.y, delta.z);
+			//ImmersiveRailroading.info("Block obstructing dismount at %s %s %s, attempting to revert to default dismount point", delta.x, delta.y, delta.z);
+			passenger.sendMessage(ChatText.DISMOUNT_DEFAULT.getMessage());
 		}
 		
 		delta = this.getPositionVector().add(new Vec3d(0, this.getDefinition().getHeight(gauge), 0));
@@ -349,11 +351,12 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 		dhstate = world.getBlockState(dhp);
 		dlstate = world.getBlockState(dlp);
 		if (dhstate.getCollisionBoundingBox(world, dhp) == null && dlstate.getCollisionBoundingBox(world, dlp) == null) {
-			ImmersiveRailroading.info("Default position at %s %s %s clear, dismounting.", delta.x, delta.y, delta.z);
+			//ImmersiveRailroading.info("Default position at %s %s %s clear, dismounting.", delta.x, delta.y, delta.z);
 			return delta;
 		}
 		
-		ImmersiveRailroading.info("Default position at %s %s %s obstructed. Dismount failed.", delta.x, delta.y, delta.z);
+		//ImmersiveRailroading.info("Default position at %s %s %s obstructed. Dismount failed.", delta.x, delta.y, delta.z);
+		passenger.sendMessage(ChatText.DISMOUNT_FAIL_DEFAULT.getMessage());
 		return new Vec3d(0,-1,0);
 	}
 

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
@@ -24,7 +24,6 @@ import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
@@ -335,11 +335,9 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 				return delta;
 			}
 			//ImmersiveRailroading.warn("Train obstructing dismount at %s %s %s, attempting to revert to default dismount point",  delta.x, delta.y, delta.z);
-			passenger.sendMessage(ChatText.DISMOUNT_DEFAULT.getMessage());
 			ImmersiveRailroading.warn("This is not intended to happen! Please contact the devs with the relavant train: %s", this.getDefinition().name());
 		} else {
 			//ImmersiveRailroading.info("Block obstructing dismount at %s %s %s, attempting to revert to default dismount point", delta.x, delta.y, delta.z);
-			passenger.sendMessage(ChatText.DISMOUNT_DEFAULT.getMessage());
 		}
 		
 		delta = this.getPositionVector().add(new Vec3d(0, this.getDefinition().getHeight(gauge), 0));

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
@@ -352,7 +352,7 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 		// ImmersiveRailroading.info("All dismounts obstructed, attempting to revert to default dismount point", delta.x, delta.y, delta.z);
 		if (this instanceof EntityMoveableRollingStock) {
 			if(((EntityMoveableRollingStock)this).getCurrentSpeed().metric() / ConfigDamage.entitySpeedDamage > 1) {
-				passenger.sendMessage(ChatText.DISMOUNT_FAIL_DEFAULT.getMessage());
+				passenger.sendMessage(ChatText.DISMOUNT_FAIL_SPEED.getMessage());
 				return new Vec3d(0,-1,0);
 			} 
 		}

--- a/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
+++ b/src/main/java/cam72cam/immersiverailroading/entity/EntityRidableRollingStock.java
@@ -333,14 +333,27 @@ public abstract class EntityRidableRollingStock extends EntityBuildableRollingSt
 		if ((dhstate.getCollisionBoundingBox(world, dhp) == null || BlockUtil.isIRRail(world, dhp)) && (dlstate.getCollisionBoundingBox(world, dlp) == null || BlockUtil.isIRRail(world, dlp))) {
 			if(!passenger.getEntityBoundingBox().offset(delta.subtract(passenger.getPositionVector())).intersects(this.getCollisionBoundingBox())) {
 				ImmersiveRailroading.info("Successful dismount at %s %s %s",  delta.x, delta.y, delta.z);
-				delta = new Vec3d(delta.x, delta.y, delta.z);
 				return delta;
 			}
-			ImmersiveRailroading.info("Train obstructing dismount at %s %s %s",  delta.x, delta.y, delta.z);
+			ImmersiveRailroading.info("Train obstructing dismount at %s %s %s, attempting to revert to default dismount point",  delta.x, delta.y, delta.z);
 		} else {
-			ImmersiveRailroading.info("Block obstructing dismount at %s %s %s.", delta.x, delta.y, delta.z);
+			ImmersiveRailroading.info("Block obstructing dismount at %s %s %s, attempting to revert to default dismount point", delta.x, delta.y, delta.z);
 		}
 		
+		delta = this.getPositionVector().add(new Vec3d(0, this.getDefinition().getHeight(gauge), 0));
+		dlp = new BlockPos(delta);
+		dhp = new BlockPos(delta.add(new Vec3d(0, 1, 0)));
+		if (!world.isBlockLoaded(dhp) || !world.isBlockLoaded(dlp)) {
+			return new Vec3d(0,-1,0);
+		}
+		dhstate = world.getBlockState(dhp);
+		dlstate = world.getBlockState(dlp);
+		if (dhstate.getCollisionBoundingBox(world, dhp) == null && dlstate.getCollisionBoundingBox(world, dlp) == null) {
+			ImmersiveRailroading.info("Default position at %s %s %s clear, dismounting.", delta.x, delta.y, delta.z);
+			return delta;
+		}
+		
+		ImmersiveRailroading.info("Default position at %s %s %s obstructed. Dismount failed.", delta.x, delta.y, delta.z);
 		return new Vec3d(0,-1,0);
 	}
 

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -32,8 +32,7 @@ public enum ChatText {
 	RADIO_NOLINK("radio.nolink"),
 	RADIO_CANT_LINK("radio.cant_link"),
 	DISMOUNT_FAIL("dismount.fail"),
-	DISMOUNT_FAIL_DEFAULT("dismount.fail_default"),
-	DISMOUNT_DEFAULT("dismount.default")
+	DISMOUNT_FAIL_DEFAULT("dismount.fail_default")
 	;
 	
 	private String value;

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -31,8 +31,8 @@ public enum ChatText {
 	RADIO_UNLINK("radio.unlink"),
 	RADIO_NOLINK("radio.nolink"),
 	RADIO_CANT_LINK("radio.cant_link"),
-	DISMOUNT_FAIL("dismount.fail"),
-	DISMOUNT_FAIL_DEFAULT("dismount.fail_default")
+	DISMOUNT_FAIL_DEFAULT("dismount.fail_default"),
+	DISMOUNT_FAIL_SPEED("dismount.fail_speed")
 	;
 	
 	private String value;

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -31,7 +31,9 @@ public enum ChatText {
 	RADIO_UNLINK("radio.unlink"),
 	RADIO_NOLINK("radio.nolink"),
 	RADIO_CANT_LINK("radio.cant_link"),
-	DISMOUNT_FAIL("dismount.fail")
+	DISMOUNT_FAIL("dismount.fail"),
+	DISMOUNT_FAIL_DEFAULT("dismount.fail_default"),
+	DISMOUNT_DEFAULT("dismount.default")
 	;
 	
 	private String value;

--- a/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
+++ b/src/main/java/cam72cam/immersiverailroading/library/ChatText.java
@@ -31,6 +31,7 @@ public enum ChatText {
 	RADIO_UNLINK("radio.unlink"),
 	RADIO_NOLINK("radio.nolink"),
 	RADIO_CANT_LINK("radio.cant_link"),
+	DISMOUNT_FAIL("dismount.fail")
 	;
 	
 	private String value;

--- a/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
+++ b/src/main/java/cam72cam/immersiverailroading/registry/EntityRollingStockDefinition.java
@@ -627,6 +627,10 @@ public abstract class EntityRollingStockDefinition {
 		return (int)Math.ceil(gauge.scale() * this.weight);
 	}
 
+	public double getWidth(Gauge gauge) {
+		return gauge.scale() * this.widthBounds;
+	}
+	
 	public double getHeight(Gauge gauge) {
 		return gauge.scale() * this.heightBounds;
 	}

--- a/src/main/resources/assets/immersiverailroading/lang/en_US.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_US.lang
@@ -51,6 +51,8 @@ chat.immersiverailroading:radio.relink=Card linked to new locomotive
 chat.immersiverailroading:radio.unlink=Card unlinked from its locomotive
 chat.immersiverailroading:radio.nolink=Card has no linked locomotive
 chat.immersiverailroading:radio.cant_link=Locomotive %s does not have radio control equipment
+chat.immersiverailroading:dismount.fail=Dismount obstructed, attemping to dismount at default position
+chat.immersiverailroading:dismount.fail_default=Default position obstructed, dismount cancelled
 
 gui.immersiverailroading:label.brake=Brake
 gui.immersiverailroading:label.throttle=Throttle

--- a/src/main/resources/assets/immersiverailroading/lang/en_US.lang
+++ b/src/main/resources/assets/immersiverailroading/lang/en_US.lang
@@ -51,8 +51,8 @@ chat.immersiverailroading:radio.relink=Card linked to new locomotive
 chat.immersiverailroading:radio.unlink=Card unlinked from its locomotive
 chat.immersiverailroading:radio.nolink=Card has no linked locomotive
 chat.immersiverailroading:radio.cant_link=Locomotive %s does not have radio control equipment
-chat.immersiverailroading:dismount.fail=Dismount obstructed, attemping to dismount at default position
 chat.immersiverailroading:dismount.fail_default=Default position obstructed, dismount cancelled
+chat.immersiverailroading:dismount.fail_speed=Train is at speed, cannot dismount at default position
 
 gui.immersiverailroading:label.brake=Brake
 gui.immersiverailroading:label.throttle=Throttle


### PR DESCRIPTION
**Technically**
- Dismount position is independent of z-offset: anywhere in the right side of the cabin will dismount to the same distance from the right side of cab.
- Dismount will attempt to place the player up to 3m from the train, if all positions are obstructed it attempts default position (train's origin, offset to roof), else cancels dismount. Messages are provided to tell the player what went wrong.
- Standing still and holding down the dismount button will only check once*, player has to move from the last dismount attempt in the cabin to check again. *(twice apparently, I am unsure why.)

**Functionally**
- Players should never dismount into walls
- Players are able to dismount into tight spaces beside the train.

 **Issues**
- [x] Dismount distance may be too close
- [ ] Players cannot exit a completely covered train
- [ ] Holding down dismount button in cabin causes player to be rotation-locked
- [x] Default dismount position may not be safe at speed
- [ ] Performance?
