### PR TITLE
New IConditionalCollision interface that lets blocks decide whether to allow collision

### DIFF
--- a/src/main/java/cam72cam/immersiverailroading/util/IConditionalCollision.java
+++ b/src/main/java/cam72cam/immersiverailroading/util/IConditionalCollision.java
@@ -1,0 +1,26 @@
+package cam72cam.immersiverailroading.util;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+/**
+ * Blocks that implement this interface can decide whether to allow collision,
+ * depending on certain conditions.
+ */
+public interface IConditionalCollision {
+
+    /**
+     * Return whether or not a block at the given position with the given state can collide
+     * with the given damage source.
+     *
+     * @param world World the block is in.
+     * @param pos Position of the block.
+     * @param state Block state of the block.
+     * @param damageSource Damage source that would be used to collide with the block.
+     * @return Whether or not to calculate actual collision.
+     */
+    boolean canCollide(World world, BlockPos pos, IBlockState state, DamageSource damageSource);
+
+}


### PR DESCRIPTION
For a mod I'm making, I have a block that can be placed near a track. Normally the train would not hit this block, but if the train goes through a tight turn the block might be in the way of the train.

This PR adds the ability for blocks to skip collision checking with rolling stock so that those blocks do not get destroyed.

https://i.imgur.com/Iw9sRqF.png

I would love to hear your thoughts on this problem and this solution.